### PR TITLE
Test- no error on page load + basic search works

### DIFF
--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -123,6 +123,11 @@ Source: CRAN
 Version: 2.4
 Hash: 6f9efd95fe30fa735c9aa3b4de10b022
 
+Package: data.table
+Source: CRAN
+Version: 1.10.4
+Hash: 2c7c47ccb40d01c7b214c8eff818108d
+
 Package: debugme
 Source: github
 Version: 1.0.2

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -4,16 +4,23 @@ library(shiny)
 library(RSelenium)
 library(testthat)
 
-remDr 		<- remoteDriver(port = 4444)
+remDr       <- remoteDriver(port = 4444)
 remDr$open(silent = TRUE)
-sysDetails 	<- remDr$getStatus()
-browser 	<- remDr$sessionInfo$browserName
-appURL 		<- "http://127.0.0.1:8888"
+sysDetails  <- remDr$getStatus()
+browser     <- remDr$sessionInfo$browserName
+appURL      <- "http://127.0.0.1:8888"
 
 test_that("can connect to app", {  
   remDr$navigate(appURL)
   appTitle <- remDr$getTitle()[[1]]
   expect_equal(appTitle, "PQ Text Analysis")  
+})
+
+test_that("there are no errors on the page", {
+  expect_that(
+    remDr$findElement("css selector", ".shiny-output-error"),
+    throws_error('NoSuchElement')
+  )
 })
 
 remDr$close()

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -1,0 +1,25 @@
+context("search")
+
+library(shiny)
+library(RSelenium)
+library(testthat)
+
+remDr       <- remoteDriver(port = 4444)
+remDr$open(silent = TRUE)
+sysDetails  <- remDr$getStatus()
+browser     <- remDr$sessionInfo$browserName
+appURL      <- "http://127.0.0.1:8888"
+
+test_that("entering search terms returns the 30 most similar questions", {  
+  remDr$setImplicitWaitTimeout(10000)
+  remDr$navigate(appURL)
+  searchBox  <- remDr$findElement("css selector", "#question")
+  query      <- "prison joint enterprise cost"
+  searchBox$sendKeysToElement(list(query))
+  oddResultsRows  <- remDr$findElements("css selector", ".odd")
+  evenResultsRows <- remDr$findElements("css selector", ".even")
+  totalRowCount   <- length(oddResultsRows) + length(evenResultsRows)
+  expect_equal(totalRowCount, 30)
+})
+
+remDr$close()


### PR DESCRIPTION
Here I add another test into the basic-test file which ensures there is no error displayed on page load.

This was added because I was experiencing such an error and this test ensures we do not go back to that place!

The other test is an integration test that just ensures some results are returned when a search is conducted.  Given that we cannot ensure the same results will be returned every time, in the long term, I didn't want to do too much here because that would make the tests brittle.

Let me know what you think and whether we should be testing more here.