### PR TITLE
Exit code must equal 1 when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
   - until nc -z localhost 4444; do sleep 3; echo 'Waiting for Selenium server'; done
   - R -e "library(shiny); runApp(port=8888)" >/dev/null &
   - until nc -z localhost 8888; do sleep 3; echo 'Waiting for Shiny server'; done
-  - R -e "devtools::test()"
+  - R -e "devtools::test(reporter = 'stop')"


### PR DESCRIPTION
1 == bad
0 == good

When tests / quality control processes are run on CI platforms such as TravisCI, they need to 'exit' (finish) with the appropriate code so that TravisCI (in this case) knows what to do next.

I.e. When some tests fail, which have to run inside an R session, that R session should exit and return '1', which then tells TravisCI that something has gone wrong and the build should be marked as 'failed'.

By default, this does not happen when using `devtools::test()` but adding `reporter = 'stop'` as an argument fixes this. Now, R calls `stop()` when a test fails, which will exit the R session with '1'.  You can test this on the command line:

R -e "stop('error')"
echo $?

Now that this is 'fixed' the build should fail until I merge in Sam's changes.