### PR TITLE
Temporary fix for TextLive fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 language: r
 r:
   - '3.4.0'
+latex: false
 warnings_are_errors: false
 sudo: false
 cache:


### PR DESCRIPTION
The Travis build was failing on all our branches due to an issue with TextLive (an external dependency).

The author of TextLive is working on a fix.

For now... I have implemented the fix suggested here: https://github.com/travis-ci/travis-ci/issues/7852