### PR TITLE
Add party

### DIFF
--- a/R/apiClient.R
+++ b/R/apiClient.R
@@ -67,8 +67,8 @@ party <- function(member) {
 
   member <- gsub('Mr |Ms |Mrs ', '', member)
   member <- strsplit(member, ' ')[[1]]
-
-  member_of_the_upper_house <- any(upper_house_titles %in% member)
+  
+  member_of_the_upper_house <- any(upper_house_titles %in% member[1:length(member) - 1])
 
   if(member_of_the_upper_house == TRUE) {return('Not found')}
 

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -149,8 +149,8 @@ Hash: 576a9d297a567d6a5ebd164ca5221590
 
 Package: curl
 Source: CRAN
-Version: 2.4
-Hash: 6f9efd95fe30fa735c9aa3b4de10b022
+Version: 2.7
+Hash: 1d97b529645be4e502fad3db22415e66
 
 Package: data.table
 Source: CRAN
@@ -207,6 +207,11 @@ Source: CRAN
 Version: 0.2.0
 Hash: e5a3b0b96a39f5581467b0c6366f7408
 Requires: magrittr, tibble
+
+Package: getopt
+Source: CRAN
+Version: 1.20.0
+Hash: 951e83029bb5f798b53d7b53cbc50be9
 
 Package: ggplot2
 Source: CRAN
@@ -366,6 +371,12 @@ Package: openssl
 Source: CRAN
 Version: 0.9.6
 Hash: 5f4711e142a44655dfea4d64fcf2f641
+
+Package: optparse
+Source: CRAN
+Version: 1.3.2
+Hash: 43f92c822f50e22bd4d8408e7ed89651
+Requires: getopt
 
 Package: packrat
 Source: CRAN

--- a/tests/testthat/test-api-client.R
+++ b/tests/testthat/test-api-client.R
@@ -208,6 +208,18 @@ test_that('party() cannot retrieve party for members of HoL', {
   expect_true( all(hol_parties %in% 'Not found') )
 })
 
+test_that('party() can return the party for people whose name includes Lord', {
+
+  with_mock(
+    `fromJSON` = function(actual_API_call) {
+      dummy_member_api_response()
+    },
+    member_party <- party('Someone Lord'),
+    expect_equal(member_party, 'Party')
+  )
+
+})
+
 test_that('party() calls the API with the correct params', {
 
   member_endpoint   <- 'http://lda.data.parliament.uk/members.json'


### PR DESCRIPTION
- This uses the members API to add information about which party each MP belongs to.
- Unfortunately the API does not serve this information for members of the HoL.